### PR TITLE
Fixed animation issue

### DIFF
--- a/src/ko.loadingWhen.js
+++ b/src/ko.loadingWhen.js
@@ -31,7 +31,7 @@ ko.bindingHandlers.loadingWhen = {
 
         if (isLoading) {
             $childrenToHide.css("visibility", "hidden").attr("disabled", "disabled");
-            $loader.show();
+            $loader.stop(true, true).show();
         }
         else {
             $loader.fadeOut("fast");


### PR DESCRIPTION
Stopped the fadeout animation running before showing the loader to prevent the case where it's shown during a fade out, causing it to disappear again once the fade out completes.
