### PR TITLE
conditionally call loadingWhen handler

### DIFF
--- a/src/ko.command.js
+++ b/src/ko.command.js
@@ -139,12 +139,16 @@ ko.command = function (options) {
 ko.bindingHandlers.command = {
 	init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
 		var command = ko.unwrap(valueAccessor());
-		ko.bindingHandlers.loadingWhen.init.call(this, element, command.isRunning, allBindingsAccessor);
+		if (!allBindingsAccessor.get("suppressLoadingWhen")) {
+			ko.bindingHandlers.loadingWhen.init.call(this, element, command.isRunning, allBindingsAccessor);
+		}
 		ko.bindingHandlers.click.init.call(this, element, ko.observable(command), allBindingsAccessor, viewModel, bindingContext);
 	},
 	update: function (element, valueAccessor, allBindingsAccessor) {
 		var command = ko.unwrap(valueAccessor());
-		ko.bindingHandlers.loadingWhen.update.call(this, element, command.isRunning, allBindingsAccessor);
+		if (!allBindingsAccessor.get("suppressLoadingWhen")) {
+			ko.bindingHandlers.loadingWhen.update.call(this, element, command.isRunning, allBindingsAccessor);
+		}
 		ko.bindingHandlers.enable.update.call(this, element, command.canExecute, allBindingsAccessor);
 	}
 };


### PR DESCRIPTION
Consider adding flag to suppress loadingWhen handler, because default functionality can (and actually does) break existing markup.
And now we can use existing styles depending on isRunning, canExecute... f.e.:

```
<span class="button common" data-bind="command: exec, suppressLoadingWhen: true, css: { disabled: !exec.canExecute() }"></span>
```